### PR TITLE
Fix missing import and typos

### DIFF
--- a/b2backend.py
+++ b/b2backend.py
@@ -27,6 +27,7 @@ import hashlib
 
 import duplicity.backend
 from duplicity.errors import BackendException, FatalBackendException
+from duplicity import log
 
 import json
 import urllib2

--- a/b2backend.py
+++ b/b2backend.py
@@ -178,9 +178,9 @@ class B2Backend(duplicity.backend.Backend):
     def _error_code(self, operation, e):
         if isinstance(e, urllib2.HTTPError):
             if e.code == 500:
-                return log.ErrorCode.backed_error
+                return log.ErrorCode.backend_error
             if e.code == 403:
-                return log.ErrorCode.backed_permission_denied
+                return log.ErrorCode.backend_permission_denied
 
     def find_or_create_bucket(self, bucket_name):
         """


### PR DESCRIPTION
I ran into the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/duplicity", line 1525, in <module>
    with_tempdir(main)
  File "/usr/local/bin/duplicity", line 1519, in with_tempdir
    fn()
  File "/usr/local/bin/duplicity", line 1373, in main
    do_backup(action)
  File "/usr/local/bin/duplicity", line 1494, in do_backup
    full_backup(col_stats)
  File "/usr/local/bin/duplicity", line 563, in full_backup
    globals.backend)
  File "/usr/local/bin/duplicity", line 444, in write_multivol
    (tdp, dest_filename, vol_num)))
  File "/usr/local/lib/python2.7/dist-packages/duplicity/asyncscheduler.py", line 146, in schedule_task
    return self.__run_synchronously(fn, params)
  File "/usr/local/lib/python2.7/dist-packages/duplicity/asyncscheduler.py", line 172, in __run_synchronously
    ret = fn(*params)
  File "/usr/local/bin/duplicity", line 443, in <lambda>
    async_waiters.append(io_scheduler.schedule_task(lambda tdp, dest_filename, vol_num: put(tdp, dest_filename, vol_num),
  File "/usr/local/bin/duplicity", line 335, in put
    backend.put(tdp, dest_filename)
  File "/usr/local/lib/python2.7/dist-packages/duplicity/backend.py", line 374, in inner_retry
    code = _get_code_from_exception(self.backend, operation, e)
  File "/usr/local/lib/python2.7/dist-packages/duplicity/backend.py", line 346, in _get_code_from_exception
    return backend._error_code(operation, e) or log.ErrorCode.backend_error
  File "/usr/local/lib/python2.7/dist-packages/duplicity/backends/b2backend.py", line 180, in _error_code
    return log.ErrorCode.backed_error
NameError: global name 'log' is not defined
```

Also noticed that `backend...` was spelled `backed...`.
