### PR TITLE
Allow multiple backups in the same bucket

### DIFF
--- a/b2backend.py
+++ b/b2backend.py
@@ -131,7 +131,8 @@ class B2Backend(duplicity.backend.Backend):
         except urllib2.HTTPError:
             return []
 
-        files = [x['fileName'].split('/')[-1] for x in resp['files']]
+        files = [x['fileName'].split('/')[-1] for x in resp['files']
+                 if x['fileName'].startswith(self.path)]
 
         next_file = resp['nextFileName']
         while next_file:
@@ -141,7 +142,8 @@ class B2Backend(duplicity.backend.Backend):
             except urllib2.HTTPError:
                 return files
 
-            files += [x['fileName'].split('/')[-1] for x in resp['files']]
+            files += [x['fileName'].split('/')[-1] for x in resp['files']
+                      if x['fileName'].startswith(self.path)]
             next_file = resp['nextFileName']
 
         return files


### PR DESCRIPTION
I tried to store multiple backups in the same bucket, but only the first one succeeded.  `_list()` was returning all the files in the bucket, not just the ones stored at the given path, which broke duplicity's synchronization step at the beginning of the backup.  This PR adds filtering to the file listing to only return files within the given path.
