### PR TITLE
Set fake (otherwise unused) hostname for prettier password prompt

### DIFF
--- a/b2backend.py
+++ b/b2backend.py
@@ -45,6 +45,9 @@ class B2Backend(duplicity.backend.Backend):
         """
         duplicity.backend.Backend.__init__(self, parsed_url)
 
+        # for prettier password prompt only
+        self.parsed_url.hostname = 'B2'
+
         self.account_id = parsed_url.username
         account_key = self.get_password()
 


### PR DESCRIPTION
Not sure if this will have unintended side-effects down the road, but it makes the password prompt look more sensible:

Before:
`Password for 'abcdef123456@None':`

After:
`Password for 'abcdef123456@B2':`
